### PR TITLE
NET 6899

### DIFF
--- a/nsgcli/response_formatter.py
+++ b/nsgcli/response_formatter.py
@@ -13,7 +13,7 @@ import dateutil.tz
 import pytz
 from tabulate import tabulate
 
-TIME_COLUMNS = ['time', 'createdAt', 'updatedAt', 'accessedAt', 'expiresAt', 'localTimeMs', 'activeSince',
+TIME_COLUMNS = ['time', 'createdAt', 'updatedAt', 'accessedAt', 'expiresAt', 'startsAt', 'localTimeMs', 'activeSince',
                 'timeOfLastNotification', 'createdAt']
 TIME_ISO8601_COLUMNS = ['discoveryStartTime', 'discoveryFinishTime', 'processingFinishTime']
 
@@ -61,12 +61,12 @@ class ResponseFormatter(object):
             columns.append(col['text'])
 
         rows = resp.get('rows', [])
-        for idx in range(0, len(columns)):
-            columns[idx] = self.transform_column_title(columns[idx])
         if rows:
             for row in rows:
                 for idx in range(0, len(columns)):
                     row[idx] = self.transform_value(columns[idx], row[idx])
+        for idx in range(0, len(columns)):
+            columns[idx] = self.transform_column_title(columns[idx])
         print(tabulate(rows, columns, tablefmt='fancy_outline'))
         processing_time_sec = resp.get('processingTimeMs', 0) / 1000.0
         server = resp.get('server', '')


### PR DESCRIPTION
Fix issue with nsgql not converting timestamp to human readable format. 

Cause: 
Column headers were updated before transforming the row value. Transforming row value depends on column names. 

Fix: 
Update column headers after updating row value 

- Added `startsAt ` in the Time columns fix 


```
https://labdcbig3.netspyglass.com:9100 > select id, createdAt, expirationTime, expiresAt, startsAt, updatedAt from silences;
╒══════╤════════════════════════════╤══════════════════╤════════════════════════════╤════════════════════════════╤════════════════════════════╕
│   id │ createdAt (local)          │   expirationTime │ expiresAt (local)          │ startsAt (local)           │ updatedAt (local)          │
╞══════╪════════════════════════════╪══════════════════╪════════════════════════════╪════════════════════════════╪════════════════════════════╡
│    4 │ 2022-05-14 00:35:45.859000 │           525615 │ 2023-05-13 20:35:45.770000 │ 2022-05-13 20:20:45.770000 │ 2022-07-18 23:11:28.347000 │
╘══════╧════════════════════════════╧══════════════════╧════════════════════════════╧════════════════════════════╧════════════════════════════╛
Count: 1, served by: labdcbig3-nsg-api-1, processing time: 0.075 sec; query id: 1658872762087
```

```
https://labdcbig3.netspyglass.com:9100 > select triplet,time,metric, updatedAt from ifInRate where triplet='ifInRate.6.8' and time between 'now-10m' and now
╒══════════════╤═════════════════════╤═════════════╤════════════════════════════╕
│ triplet      │ time (utc)          │      metric │ updatedAt (utc)            │
╞══════════════╪═════════════════════╪═════════════╪════════════════════════════╡
│ ifInRate.6.8 │ 2022-08-02 12:50:00 │ 3.6593e+08  │ 2022-08-02 12:59:58.161000 │
│ ifInRate.6.8 │ 2022-08-02 12:51:00 │ 3.17931e+08 │ 2022-08-02 12:59:58.161000 │
│ ifInRate.6.8 │ 2022-08-02 12:52:00 │ 2.7153e+08  │ 2022-08-02 12:59:58.161000 │
│ ifInRate.6.8 │ 2022-08-02 12:53:00 │ 1.79926e+08 │ 2022-08-02 12:59:58.161000 │
│ ifInRate.6.8 │ 2022-08-02 12:54:00 │ 3.10843e+08 │ 2022-08-02 12:59:58.161000 │
│ ifInRate.6.8 │ 2022-08-02 12:55:00 │ 3.29723e+08 │ 2022-08-02 12:59:58.161000 │
│ ifInRate.6.8 │ 2022-08-02 12:56:00 │ 2.6642e+08  │ 2022-08-02 12:59:58.161000 │
│ ifInRate.6.8 │ 2022-08-02 12:57:00 │ 3.83051e+08 │ 2022-08-02 12:59:58.161000 │
│ ifInRate.6.8 │ 2022-08-02 12:58:00 │ 4.2399e+08  │ 2022-08-02 12:59:58.161000 │
│ ifInRate.6.8 │ 2022-08-02 12:59:00 │ 3.74254e+08 │ 2022-08-02 12:59:58.161000 │
╘══════════════╧═════════════════════╧═════════════╧════════════════════════════╛
Count: 10, served by: labdcbig3-nsg-api-2, processing time: 0.057 sec; query id: 1658872502437
```